### PR TITLE
Add manifests to samples that do not have default manifests

### DIFF
--- a/calendar/vacationCalendar/appsscript.json
+++ b/calendar/vacationCalendar/appsscript.json
@@ -1,0 +1,15 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+    "enabledAdvancedServices": [{
+      "userSymbol": "AdminDirectory",
+      "serviceId": "admin",
+      "version": "directory_v1"
+    }, {
+      "userSymbol": "Calendar",
+      "serviceId": "calendar",
+      "version": "v3"
+    }]
+  },
+  "exceptionLogging": "STACKDRIVER"
+}

--- a/simpleTasks/appsscript.json
+++ b/simpleTasks/appsscript.json
@@ -1,0 +1,11 @@
+{
+  "timeZone": "America/Los_Angeles",
+  "dependencies": {
+    "enabledAdvancedServices": [{
+      "userSymbol": "Tasks",
+      "serviceId": "tasks",
+      "version": "v1"
+    }]
+  },
+  "exceptionLogging": "STACKDRIVER"
+}


### PR DESCRIPTION
I've looked at every sample in this repo to see which ones do not have a default manifest.

_Default manifest_

```json
{
  "timeZone": "America/New_York",
  "dependencies": {
  },
  "exceptionLogging": "STACKDRIVER"
}
```

I looked at the properties defined in the [manifest structure](https://developers.google.com/apps-script/concepts/manifests) to see if there were other properties we could add. I see that the [Gmail samples](https://github.com/googlesamples/gmail-add-ons-samples) have properly added manifests.

There are two samples that have manifests that could be useful when deploying with `clasp`. They look like this:

```json
{
  "timeZone": "America/Los_Angeles",
  "dependencies": {
    "enabledAdvancedServices": [{
      "userSymbol": "AdminDirectory",
      "serviceId": "admin",
      "version": "directory_v1"
    }, {
      "userSymbol": "Calendar",
      "serviceId": "calendar",
      "version": "v3"
    }]
  },
  "exceptionLogging": "STACKDRIVER"
}
```

and

```json
{
  "timeZone": "America/Los_Angeles",
  "dependencies": {
    "enabledAdvancedServices": [{
      "userSymbol": "Tasks",
      "serviceId": "tasks",
      "version": "v1"
    }]
  },
  "exceptionLogging": "STACKDRIVER"
}
```

Let's add these manifests to these samples.